### PR TITLE
Add support for clean shutdown

### DIFF
--- a/.github/workflows/test-integ.yml
+++ b/.github/workflows/test-integ.yml
@@ -32,5 +32,6 @@ jobs:
           sudo apt-get install jq -y
       - name: Run integration tests
         run: |
-          tests/merge.sh
+          tests/nodes.sh
+          tests/controller.sh
   

--- a/gossip/node_test.go
+++ b/gossip/node_test.go
@@ -308,10 +308,6 @@ func TestNodeShutdown(t *testing.T) {
 	n.Shutdown()
 
 	//Check results
-	if len(n.Peers) != 0 {
-		t.Errorf("len(n.Peers) == %d; want %d", len(n.Peers), 0)
-	}
-
 	if !received {
 		t.Errorf("HTTP Server did not receive a request")
 	}

--- a/gossip/node_test.go
+++ b/gossip/node_test.go
@@ -284,6 +284,39 @@ func TestNodePingPeersUnreachable(t *testing.T) {
 	}
 }
 
+func TestNodeShutdown(t *testing.T) {
+	//Setup node
+	n := NewNode(nil)
+
+	//Setup peer server
+	var received bool
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("r.Method == %s; want %s", r.Method, "DELETE")
+		}
+		if r.URL.Path != "/peers" {
+			t.Errorf("r.URL.PATH == %s; want %s", r.URL.Path, "/peers")
+		}
+		received = true
+		response(w, r, http.StatusOK, "Peering request received")
+	}))
+	defer func() { testServer.Close() }()
+	peer := NewPeer(parseURL(testServer.URL), nil)
+
+	n.Peers = []*Peer{peer}
+
+	n.Shutdown()
+
+	//Check results
+	if len(n.Peers) != 0 {
+		t.Errorf("len(n.Peers) == %d; want %d", len(n.Peers), 0)
+	}
+
+	if !received {
+		t.Errorf("HTTP Server did not receive a request")
+	}
+}
+
 func TestNodeStateWorker(t *testing.T) {
 	state := State{time.Now().UnixNano(), "Test data"}
 	n := NewNode(nil)

--- a/gossip/peer.go
+++ b/gossip/peer.go
@@ -232,6 +232,40 @@ func (p *Peer) SendPeeringRequest(addr Addr) {
 	p.UpdateStatus(false)
 }
 
+/*SendPeerDeletionRequest sends a request to delete the addr from the list of
+known peers.*/
+func (p *Peer) SendPeerDeletionRequest(addr Addr) {
+	log.WithFields(log.Fields{"peer": p, "func": "SendPeerDeletionRequest"}).Infof("Sending peering request with %v", addr)
+
+	jsonVal, err := json.Marshal(addr)
+	if err != nil {
+		log.WithFields(log.Fields{"peer": p, "func": "SendPeerDeletionRequest", "addr": addr}).Warnf("Failed to marshal addr: %s", err.Error())
+		return
+	}
+
+	//Try to send a peering request to the peer
+	for i := 0; i <= p.config.Peer.MaxRetries; i++ {
+		req, err := http.NewRequest("DELETE", p.URL()+"/peers", bytes.NewBuffer(jsonVal))
+		req.Header.Add("Content-Type", "application/json")
+		if err != nil {
+			log.WithFields(log.Fields{"peer": p, "func": "SendPeerDeletionRequest", "addr": addr}).Warn("Failed to create request: %s", err.Error())
+			return
+		}
+
+		res, err := http.DefaultClient.Do(req)
+		if err == nil && res.StatusCode == http.StatusOK {
+			p.UpdateStatus(true)
+			return
+		}
+
+		//TODO: add jitter
+		time.Sleep(p.config.Peer.BackoffDuration * (1 >> i))
+	}
+
+	log.WithFields(log.Fields{"peer": p, "func": "SendPeerDeletionRequest"}).Warn("Failed to send peer deletion request")
+	p.UpdateStatus(false)
+}
+
 //String returns a string representation of the peer
 func (p Peer) String() string {
 	return p.Addr.String()

--- a/gossip/peer.go
+++ b/gossip/peer.go
@@ -235,7 +235,7 @@ func (p *Peer) SendPeeringRequest(addr Addr) {
 /*SendPeerDeletionRequest sends a request to delete the addr from the list of
 known peers.*/
 func (p *Peer) SendPeerDeletionRequest(addr Addr) {
-	log.WithFields(log.Fields{"peer": p, "func": "SendPeerDeletionRequest"}).Infof("Sending peering request with %v", addr)
+	log.WithFields(log.Fields{"peer": p, "func": "SendPeerDeletionRequest"}).Infof("Sending peer deletion request to %v", addr)
 
 	jsonVal, err := json.Marshal(addr)
 	if err != nil {
@@ -248,7 +248,7 @@ func (p *Peer) SendPeerDeletionRequest(addr Addr) {
 		req, err := http.NewRequest("DELETE", p.URL()+"/peers", bytes.NewBuffer(jsonVal))
 		req.Header.Add("Content-Type", "application/json")
 		if err != nil {
-			log.WithFields(log.Fields{"peer": p, "func": "SendPeerDeletionRequest", "addr": addr}).Warn("Failed to create request: %s", err.Error())
+			log.WithFields(log.Fields{"peer": p, "func": "SendPeerDeletionRequest", "addr": addr}).Warnf("Failed to create request: %s", err.Error())
 			return
 		}
 

--- a/gossip/peer_test.go
+++ b/gossip/peer_test.go
@@ -50,6 +50,29 @@ func TestPeerCanPeer(t *testing.T) {
 	}
 }
 
+func TestPeerDelete(t *testing.T) {
+	//Setup node
+	var received bool
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("r.Method == %s; want %s", r.Method, "DELETE")
+		}
+		if r.URL.Path != "/peers" {
+			t.Errorf("r.URL.PATH == %s; want %s", r.URL.Path, "/peers")
+		}
+		received = true
+		response(w, r, http.StatusOK, "Peering request received")
+	}))
+	defer func() { testServer.Close() }()
+	peer := NewPeer(parseURL(testServer.URL), nil)
+
+	peer.SendPeerDeletionRequest(Addr{"127.0.0.1", 8080})
+
+	if !received {
+		t.Errorf("HTTP Server did not receive a request")
+	}
+}
+
 func TestPeerGet(t *testing.T) {
 	testCases := []State{
 		{0, "Test Data"},

--- a/tests/nodes.sh
+++ b/tests/nodes.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+trap ctrl_c INT
+
+function ctrl_c() {
+    kill -INT $NODE1_PID $NODE2_PID
+    exit
+}
+
+# Start nodes
+pushd ./node/
+go build .
+
+GOSSIP_NODE_PORT=8080 ./node &
+NODE1_PID=$!
+
+GOSSIP_NODE_PORT=8081 ./node &
+NODE2_PID=$!
+
+# Waiting for the peer to come online
+while ! nc -vz 127.0.0.1 8080; do
+    sleep 1
+done
+
+# Send peering
+curl -s -X POST -d '{"ip": "127.0.0.1", "port": 8081}' http://127.0.0.1:8080/peers
+sleep 1s
+
+if (( $(curl -s http://127.0.0.1:8080/peers | jq '.peers | length') < 1 )); then
+    echo "127.0.0.1:8080 does not have any peer"
+    kill -INT $NODE1_PID $NODE2_PID
+    exit 1
+fi
+
+if (( $(curl -s http://127.0.0.1:8081/peers | jq '.peers | length') < 1 )); then
+    echo "127.0.0.1:8081 does not have any peer"
+    kill -INT $NODE1_PID $NODE2_PID
+    exit 1
+fi
+
+# Shut down one peer
+kill -INT $NODE1_PID
+if (( $(curl -s http://127.0.0.1:8081/peers | jq '.peers | length') > 0 )); then
+    echo "127.0.0.1:8081 still has peers"
+    kill -INT $NODE1_PID $NODE2_PID
+    exit 1
+fi
+
+# Shut down the other peer
+kill -INT $NODE2_PID
+
+echo "Peering worked as expected"


### PR DESCRIPTION
With this PR, nodes will send DELETE /peers requests to their peers before shutting down. This prevents the peers from waiting 5 minutes (by default) to remove the node from their list of peers.

Implements https://github.com/nmoutschen/gossip/issues/15