### PR TITLE
Add IP address auto-detection for DELETE/POST /peers on nodes

### DIFF
--- a/gossip/node_handlers.go
+++ b/gossip/node_handlers.go
@@ -3,6 +3,7 @@ package gossip
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -35,6 +36,13 @@ func (n *Node) peersDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	/*Infer that the client node does not know its IP address and use the one
+	from the HTTP request instead.
+	*/
+	if addr.IP == "" {
+		addr.IP = strings.SplitN(r.RemoteAddr, ":", 1)[0]
+	}
+
 	n.deletePeerChan <- *addr
 	response(w, r, http.StatusOK, "Peer deletion request received")
 }
@@ -60,6 +68,13 @@ func (n *Node) peersPostHandler(w http.ResponseWriter, r *http.Request) {
 		log.WithFields(log.Fields{"node": n, "func": "peersPostHandler"}).Warnf("Failed to decode request body: %s", err.Error())
 		response(w, r, http.StatusInternalServerError, "Failed to decode request body")
 		return
+	}
+
+	/*Infer that the client node does not know its IP address and use the one
+	from the HTTP request instead.
+	*/
+	if addr.IP == "" {
+		addr.IP = strings.SplitN(r.RemoteAddr, ":", 1)[0]
 	}
 
 	n.addPeerChan <- *addr

--- a/gossip/node_handlers_test.go
+++ b/gossip/node_handlers_test.go
@@ -60,6 +60,34 @@ func TestNodePeersHandlerPost(t *testing.T) {
 	}
 }
 
+func TestNodePeersHandlerPostNoIP(t *testing.T) {
+	//Prepare address and node
+	addr := Addr{"", 8081}
+	n := NewNode(nil)
+	reqBody, _ := json.Marshal(addr)
+
+	//Send request
+	req := httptest.NewRequest("POST", n.URL()+"/peers", bytes.NewBuffer(reqBody))
+	w := httptest.NewRecorder()
+	n.peersHandler(w, req)
+	res := w.Result()
+
+	//Parse response
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("res.StatusCode == %d; want %d", res.StatusCode, http.StatusOK)
+	} else {
+		rAddr := <-n.addPeerChan
+
+		if rAddr.IP != req.RemoteAddr {
+			t.Errorf("rAddr.IP == %s; want %s", rAddr.IP, req.RemoteAddr)
+		}
+
+		if rAddr.Port != addr.Port {
+			t.Errorf("rAddr.Port == %d; want %d", rAddr.Port, addr.Port)
+		}
+	}
+}
+
 func TestNodePeersHandlerDelete(t *testing.T) {
 	//Prepare address and node
 	addr := Addr{"127.0.0.1", 8081}
@@ -82,7 +110,34 @@ func TestNodePeersHandlerDelete(t *testing.T) {
 			t.Errorf("rAddr == %v; want %v", rAddr, addr)
 		}
 	}
+}
 
+func TestNodePeersHandlerDeleteNoIP(t *testing.T) {
+	//Prepare address and node
+	addr := Addr{"", 8081}
+	n := NewNode(nil)
+	reqBody, _ := json.Marshal(addr)
+
+	//Send request
+	req := httptest.NewRequest("DELETE", n.URL()+"/peers", bytes.NewBuffer(reqBody))
+	w := httptest.NewRecorder()
+	n.peersHandler(w, req)
+	res := w.Result()
+
+	//Parse response
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("res.StatusCode == %d; want %d", res.StatusCode, http.StatusOK)
+	} else {
+		rAddr := <-n.deletePeerChan
+
+		if rAddr.IP != req.RemoteAddr {
+			t.Errorf("rAddr.IP == %s; want %s", rAddr.IP, req.RemoteAddr)
+		}
+
+		if rAddr.Port != addr.Port {
+			t.Errorf("rAddr.Port == %d; want %d", rAddr.Port, addr.Port)
+		}
+	}
 }
 
 func TestNodePeersHandlerOptions(t *testing.T) {

--- a/gossip/node_test.go
+++ b/gossip/node_test.go
@@ -161,6 +161,7 @@ func TestNodePeerSendStateWorker(t *testing.T) {
 			Message: "State received",
 		})
 	}))
+	defer func() { testServer.Close() }()
 	peer := NewPeer(parseURL(testServer.URL), nil)
 
 	state := State{time.Now().UnixNano(), "Test data"}


### PR DESCRIPTION
This will allow to run nodes without knowing the IP address in advance.